### PR TITLE
feat(CLI): re-introduce label-selectors for filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /result*
 /e2e-*/
 /help.txt
+/service-reflector

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Usage of service-reflector:
       --emitter.permit-address-sharing                 If true, SO_REUSEADDR will be used when binding the port. This allows binding to wildcard IPs like 0.0.0.0 and specific IPs in parallel, and it avoids waiting for the kernel to release sockets in TIME_WAIT state. [default=false]
       --emitter.permit-port-sharing                    If true, SO_REUSEPORT will be used when binding the port, which allows more than one instance to bind on the same address and port. [default=false]
       --emitter.secure-port int                        The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all. (default 6443)
+      --emitter.selector string                        Label selector to filter ServiceExports watched by the emitter (e.g. app.kubernetes.io/name=foo).
       --emitter.tls-cert-file string                   File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.
       --emitter.tls-cipher-suites strings              Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used. 
                                                        Preferred values: TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256. 
@@ -106,7 +107,9 @@ Usage of service-reflector:
       --listen string                                  Address to listen for health and metrics. (default ":9090")
       --log-level string                               Log level to use. Possible values: debug, info, warn, error (default "info")
       --namespace string                               Namespace to watch (empty = all).
-      --source-api url                                 URL of a remote Emitter to watch (repeatable).
-      --source-kubeconfig stringArray                  Kubeconfig for a remote cluster (repeatable).
+      --reflector                                      Run the local controller manager (reconcilers + watchers). (default true)
+      --reflector.selector string                      Label selector to filter remote ServiceExports processed by the reflector (e.g. app.kubernetes.io/name=foo).
+      --reflector.source-api url                       URL of a remote Emitter to watch (repeatable).
+      --reflector.source-kubeconfig stringArray        Kubeconfig for a remote cluster (repeatable).
       --version                                        Print version and exit.
 ```

--- a/cmd/service-reflector/main.go
+++ b/cmd/service-reflector/main.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
@@ -97,19 +98,25 @@ type options struct {
 	namespace    string
 	printVersion bool
 
-	runEmitter bool
-	secure     *genericoptions.SecureServingOptionsWithLoopback
+	runEmitter   bool
+	runReflector bool
+	secure       *genericoptions.SecureServingOptionsWithLoopback
+
+	emitterSelector   string
+	reflectorSelector string
 
 	sourceAPIs        urls
 	sourceKubeconfigs []string
 
 	// Completed fields
-	logger             logr.Logger
-	localConfig        *restclient.Config
-	apiserverConfig    *apiserver.Config
-	apiserverCompleted apiserver.CompletedConfig
-	seInformer         cache.SharedIndexInformer
-	esInformer         cache.SharedIndexInformer
+	logger                  logr.Logger
+	localConfig             *restclient.Config
+	apiserverConfig         *apiserver.Config
+	apiserverCompleted      apiserver.CompletedConfig
+	seInformer              cache.SharedIndexInformer
+	esInformer              cache.SharedIndexInformer
+	emitterSelectorParsed   labels.Selector
+	reflectorSelectorParsed labels.Selector
 }
 
 func newOptions() *options {
@@ -134,15 +141,24 @@ func (o *options) flagSet() *pflag.FlagSet {
 	f.StringVar(&o.namespace, "namespace", metav1.NamespaceAll, "Namespace to watch (empty = all).")
 	f.BoolVar(&o.printVersion, "version", false, "Print version and exit.")
 	f.BoolVar(&o.runEmitter, "emitter", true, "Run the local Emitter API server.")
-	f.Var(&o.sourceAPIs, "source-api", "URL of a remote Emitter to watch (repeatable).")
-	f.StringArrayVar(&o.sourceKubeconfigs, "source-kubeconfig", nil, "Kubeconfig for a remote cluster (repeatable).")
+	f.BoolVar(&o.runReflector, "reflector", true, "Run the local controller manager (reconcilers + watchers).")
 
 	emitter := pflag.NewFlagSet("emitter", pflag.ExitOnError)
 	emitter.SetNormalizeFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		return pflag.NormalizedName("emitter." + name)
 	})
+	emitter.StringVar(&o.emitterSelector, "selector", "", "Label selector to filter ServiceExports watched by the emitter (e.g. app.kubernetes.io/name=foo).")
 	o.secure.AddFlags(emitter)
 	f.AddFlagSet(emitter)
+
+	reflector := pflag.NewFlagSet("reflector", pflag.ExitOnError)
+	reflector.SetNormalizeFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+		return pflag.NormalizedName("reflector." + name)
+	})
+	reflector.StringVar(&o.reflectorSelector, "selector", "", "Label selector to filter remote ServiceExports processed by the reflector (e.g. app.kubernetes.io/name=foo).")
+	reflector.Var(&o.sourceAPIs, "source-api", "URL of a remote Emitter to watch (repeatable).")
+	reflector.StringArrayVar(&o.sourceKubeconfigs, "source-kubeconfig", nil, "Kubeconfig for a remote cluster (repeatable).")
+	f.AddFlagSet(reflector)
 
 	return f
 }
@@ -153,6 +169,32 @@ func (o *options) complete() []error {
 
 	if o.clusterID == "" {
 		errs = append(errs, fmt.Errorf("--cluster-id is required"))
+	}
+
+	if !o.runEmitter && !o.runReflector {
+		errs = append(errs, fmt.Errorf("at least one of --emitter or --reflector must be enabled"))
+	}
+
+	// Parse emitter label selector.
+	o.emitterSelectorParsed = labels.Everything()
+	if o.emitterSelector != "" {
+		parsed, err := labels.Parse(o.emitterSelector)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid --emitter.selector %q: %w", o.emitterSelector, err))
+		} else {
+			o.emitterSelectorParsed = parsed
+		}
+	}
+
+	// Parse reflector label selector.
+	o.reflectorSelectorParsed = labels.Everything()
+	if o.reflectorSelector != "" {
+		parsed, err := labels.Parse(o.reflectorSelector)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid --reflector.selector %q: %w", o.reflectorSelector, err))
+		} else {
+			o.reflectorSelectorParsed = parsed
+		}
 	}
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", o.kubeconfig)
@@ -208,7 +250,11 @@ func (o *options) completeEmitter() error {
 	if err != nil {
 		return fmt.Errorf("creating dynamic client for emitter: %w", err)
 	}
-	dynFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 0, o.namespace, nil)
+
+	tweakListOptions := func(lo *metav1.ListOptions) {
+		lo.LabelSelector = o.emitterSelectorParsed.String()
+	}
+	dynFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 0, o.namespace, tweakListOptions)
 
 	seGVR := schema.GroupVersionResource{
 		Group:    v1beta1.GroupVersion.Group,
@@ -282,8 +328,7 @@ func Main() error {
 		}
 	}
 
-	// Controller manager (reconcilers + watchers).
-	{
+	if o.runReflector {
 		remoteConfigs, err := buildRemoteConfigs(o)
 		if err != nil {
 			cancel()
@@ -292,11 +337,12 @@ func Main() error {
 		g.Add(func() error {
 			o.logger.Info("starting controller manager")
 			return controller.Start(ctx, controller.ManagerOptions{
-				KubeConfig:    o.localConfig,
-				ClusterID:     o.clusterID,
-				Namespace:     o.namespace,
-				RemoteConfigs: remoteConfigs,
-				Log:           o.logger,
+				KubeConfig:        o.localConfig,
+				ClusterID:         o.clusterID,
+				Namespace:         o.namespace,
+				RemoteConfigs:     remoteConfigs,
+				ReflectorSelector: o.reflectorSelectorParsed,
+				Log:               o.logger,
 			})
 		}, func(error) { cancel() })
 	}

--- a/manifests/service-reflector.yaml
+++ b/manifests/service-reflector.yaml
@@ -6,7 +6,9 @@ metadata:
     app.kubernetes.io/name: service-reflector
 data:
   cluster-id: ""
-  source-api: ""
+  emitter-selector: ""
+  reflector-selector: ""
+  reflector-source-api: ""
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -32,7 +34,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "discovery.k8s.io"
+  - discovery.k8s.io
   resources:
   - endpointslices
   verbs:
@@ -44,7 +46,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - "multicluster.x-k8s.io"
+  - multicluster.x-k8s.io
   resources:
   - serviceexports
   - serviceimports
@@ -57,7 +59,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - "multicluster.x-k8s.io"
+  - multicluster.x-k8s.io
   resources:
   - serviceexports/status
   - serviceimports/status
@@ -105,7 +107,9 @@ spec:
         - --cluster-id=$(CLUSTER_ID)
         - --emitter.secure-port=6443
         - --emitter.insecure-port=8080
-        - --source-api=$(SOURCE_API)
+        - --emitter.selector=$(EMITTER_SELECTOR)
+        - --reflector.selector=$(REFLECTOR_SELECTOR)
+        - --reflector.source-api=$(REFLECTOR_SOURCE_API)
         - --listen=0.0.0.0:9090
         env:
         - name: CLUSTER_ID
@@ -113,11 +117,21 @@ spec:
             configMapKeyRef:
               name: service-reflector
               key: cluster-id
-        - name: SOURCE_API
+        - name: EMITTER_SELECTOR
           valueFrom:
             configMapKeyRef:
               name: service-reflector
-              key: source-api
+              key: emitter-selector
+        - name: REFLECTOR_SELECTOR
+          valueFrom:
+            configMapKeyRef:
+              name: service-reflector
+              key: reflector-selector
+        - name: REFLECTOR_SOURCE_API
+          valueFrom:
+            configMapKeyRef:
+              name: service-reflector
+              key: reflector-source-api
         ports:
         - containerPort: 9090
           name: metrics

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,6 +40,8 @@ type ManagerOptions struct {
 	Namespace string
 	// RemoteConfigs maps remoteID -> REST config for each remote Emitter.
 	RemoteConfigs map[string]*rest.Config
+	// ReflectorSelector filters which remote ServiceExports are processed.
+	ReflectorSelector labels.Selector
 	// Log is the base logger.
 	Log logr.Logger
 }
@@ -118,6 +121,7 @@ func Start(ctx context.Context, opts ManagerOptions) error {
 			remoteConfig,
 			mgr.GetClient(),
 			opts.Namespace,
+			opts.ReflectorSelector,
 			conflictDetector,
 			opts.Log.WithName("Watcher"),
 		)

--- a/pkg/controller/watcher.go
+++ b/pkg/controller/watcher.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,6 +55,8 @@ type Watcher struct {
 	localClient client.Client
 	// namespace restricts which namespaces are watched (empty = all).
 	namespace string
+	// selector filters which remote ServiceExports are processed.
+	selector labels.Selector
 	// conflictDetector tracks remote ServiceExport specs for cross-cluster conflict detection.
 	conflictDetector *ConflictDetector
 	log              logr.Logger
@@ -66,6 +69,7 @@ func NewWatcher(
 	remoteConfig *rest.Config,
 	localClient client.Client,
 	namespace string,
+	selector labels.Selector,
 	conflictDetector *ConflictDetector,
 	log logr.Logger,
 ) *Watcher {
@@ -75,6 +79,7 @@ func NewWatcher(
 		remoteConfig:     remoteConfig,
 		localClient:      localClient,
 		namespace:        namespace,
+		selector:         selector,
 		conflictDetector: conflictDetector,
 		log:              log.WithValues("remote", remoteID),
 	}
@@ -100,6 +105,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 
 	listSE := func(opts metav1.ListOptions) (runtime.Object, error) {
+		opts.LabelSelector = w.selector.String()
 		if w.namespace != "" {
 			return dynClient.Resource(seGVR).Namespace(w.namespace).List(ctx, opts)
 		}
@@ -107,6 +113,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 	watchSE := func(opts metav1.ListOptions) (watch.Interface, error) {
 		opts.Watch = true
+		opts.LabelSelector = w.selector.String()
 		if w.namespace != "" {
 			return dynClient.Resource(seGVR).Namespace(w.namespace).Watch(ctx, opts)
 		}


### PR DESCRIPTION
This commit re-introduces pre-MCS API migration behavior that allowed
both the emitter and the reflector to filter for emitted/reflected
services using a label-selector. It also restores the CLI flags sets
that collect all reflector-related options under `--reflector*`.
